### PR TITLE
automatic finding of installed Caffe2

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -36,7 +36,7 @@ else()
 endif()
 
 # Library dependencies.
-find_package(Caffe2 REQUIRED)
+find_package(Caffe2 REQUIRED HINTS ${CMAKE_CURRENT_LIST_DIR}/../Caffe2)
 
 find_library(TORCH_LIBRARY torch PATHS "${TORCH_INSTALL_PREFIX}/lib")
 add_library(torch UNKNOWN IMPORTED)


### PR DESCRIPTION
The installed Caffe2 will automatically be found within find_package(Torch).

The provided example [cppdocs](https://pytorch.org/cppdocs/installing.html)
```
cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
project(example-app)
find_package(Torch REQUIRED)
add_executable(example-app example-app.cpp)
target_link_libraries(example-app "${TORCH_LIBRARIES}")
set_property(TARGET example-app PROPERTY CXX_STANDARD 11)
```
ends otherwise with an error: _Could not find a package configuration file provided by "Caffe2" with any..._



